### PR TITLE
flake: url litterals are deprecated in Lix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    ttfautohint.url = github:toaq/ttfautohint;
+    ttfautohint.url = "github:toaq/ttfautohint";
   };
 
   outputs = { self, nixpkgs, flake-utils, ttfautohint, ... }:


### PR DESCRIPTION
tua poa maq #5 